### PR TITLE
Update md-grid-layout.html

### DIFF
--- a/app-grid/demo/md-grid-layout.html
+++ b/app-grid/demo/md-grid-layout.html
@@ -52,6 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           --app-grid-gutter: 10px;
           --app-grid-expandible-item-columns: 4;
           --paper-icon-button-ink-color: white;
+          --app-grid-item-height: 200px;
         }
 
         app-header {
@@ -94,7 +95,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           padding: 16px;
         }
 
-        @media(max-width: 799px) {
+        @media screen and (max-width: 799px) {
 
           .centered-container {
             margin: 10px 5px;


### PR DESCRIPTION
As per issue: [https://github.com/PolymerElements/app-layout/issues/528](url)

The Material Design grid demo is broken for Firefox and Edge.

It looks like adding `--app-grid-item-height: 200px;` to the :host style fixes the problem. It's in the media query section only.

Also, I noticed with Edge the media query is not working either. Adding `screen and` to the media query appears to fix that also.